### PR TITLE
Add metric for oldest run_at per queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ sidekiq_retry_jobs                         gauge    The number of jobs scheduled
 sidekiq_dead_jobs                          gauge    The number of jobs being dead.
 sidekiq_queue_latency_seconds              gauge    The amount of seconds between oldest job being pushed
                                                     to the queue and current time (labels: name).
+sidekiq_queue_max_processing_time_seconds  gauge    The amount of seconds between oldest job of the queue
+                                                    being executed and current time.
 sidekiq_queue_enqueued_jobs                gauge    The number of enqueued jobs in the queue (labels: name).
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ Open [dashboard example file](/examples/sidekiq.json), then open `https://<your 
 (starting Sidekiq `v3.3.1`)
 
 ```text
-sidekiq_processed_jobs_total   counter  The total number of processed jobs.
-sidekiq_failed_jobs_total      counter  The total number of failed jobs.
-sidekiq_busy_workers           gauge    The number of workers performing the job.
-sidekiq_enqueued_jobs          gauge    The number of enqueued jobs.
-sidekiq_scheduled_jobs         gauge    The number of jobs scheduled for a future execution.
-sidekiq_retry_jobs             gauge    The number of jobs scheduled for the next try.
-sidekiq_dead_jobs              gauge    The number of jobs being dead.
-sidekiq_queue_latency_seconds  gauge    The amount of seconds between oldest job being pushed
-                                        to the queue and current time (labels: name).
-sidekiq_queue_enqueued_jobs    gauge    The number of enqueued jobs in the queue (labels: name).
+sidekiq_processed_jobs_total               counter  The total number of processed jobs.
+sidekiq_failed_jobs_total                  counter  The total number of failed jobs.
+sidekiq_busy_workers                       gauge    The number of workers performing the job.
+sidekiq_enqueued_jobs                      gauge    The number of enqueued jobs.
+sidekiq_scheduled_jobs                     gauge    The number of jobs scheduled for a future execution.
+sidekiq_retry_jobs                         gauge    The number of jobs scheduled for the next try.
+sidekiq_dead_jobs                          gauge    The number of jobs being dead.
+sidekiq_queue_latency_seconds              gauge    The amount of seconds between oldest job being pushed
+                                                    to the queue and current time (labels: name).
+sidekiq_queue_enqueued_jobs                gauge    The number of enqueued jobs in the queue (labels: name).
 ```
 
 # Installation

--- a/gemfiles/sidekiq_3.3.1.gemfile.lock
+++ b/gemfiles/sidekiq_3.3.1.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     temple (0.8.0)
     thor (0.20.0)
     tilt (2.0.8)
+    timecop (0.9.1)
     timers (4.1.2)
       hitimes
     unicode-display_width (1.4.0)
@@ -131,6 +132,7 @@ DEPENDENCIES
   sidekiq-prometheus-exporter!
   sinatra
   slim
+  timecop (~> 0.9)
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/gemfiles/sidekiq_3.x.gemfile.lock
+++ b/gemfiles/sidekiq_3.x.gemfile.lock
@@ -108,6 +108,7 @@ GEM
     temple (0.8.0)
     thor (0.20.0)
     tilt (2.0.8)
+    timecop (0.9.1)
     timers (4.1.2)
       hitimes
     unicode-display_width (1.4.0)
@@ -131,6 +132,7 @@ DEPENDENCIES
   sidekiq-prometheus-exporter!
   sinatra
   slim
+  timecop (~> 0.9)
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/gemfiles/sidekiq_4.x.gemfile.lock
+++ b/gemfiles/sidekiq_4.x.gemfile.lock
@@ -76,6 +76,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thor (0.20.0)
+    timecop (0.9.1)
     unicode-display_width (1.4.0)
 
 PLATFORMS
@@ -94,6 +95,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.28.0)
   sidekiq (~> 4.0)
   sidekiq-prometheus-exporter!
+  timecop (~> 0.9)
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/gemfiles/sidekiq_5.x.gemfile.lock
+++ b/gemfiles/sidekiq_5.x.gemfile.lock
@@ -74,6 +74,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thor (0.20.0)
+    timecop (0.9.1)
     unicode-display_width (1.4.0)
 
 PLATFORMS
@@ -92,6 +93,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.28.0)
   sidekiq (~> 5.0)
   sidekiq-prometheus-exporter!
+  timecop (~> 0.9)
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/lib/sidekiq/prometheus/exporter/metrics.rb
+++ b/lib/sidekiq/prometheus/exporter/metrics.rb
@@ -10,6 +10,7 @@ module Sidekiq
       def initialize
         @overview_stats = Sidekiq::Stats.new
         @queues_stats = queues_stats
+        @oldest_run_ats = oldest_run_ats
       end
 
       def __binding__
@@ -22,6 +23,15 @@ module Sidekiq
         Sidekiq::Queue.all.map do |queue|
           QueueStats.new(queue.name, queue.size, queue.latency)
         end
+      end
+
+      def oldest_run_ats
+        works_per_queue = Sidekiq::Workers.new.map { |_, _, work| work }.group_by { |work| work['queue'] }
+        oldest_work_per_queue = works_per_queue.map do |queue, works|
+          oldest_work = works.min_by { |work| work['run_at'] }
+          [queue, oldest_work['run_at']]
+        end
+        oldest_work_per_queue.to_h
       end
     end
   end

--- a/lib/sidekiq/prometheus/exporter/metrics.rb
+++ b/lib/sidekiq/prometheus/exporter/metrics.rb
@@ -10,7 +10,7 @@ module Sidekiq
       def initialize
         @overview_stats = Sidekiq::Stats.new
         @queues_stats = queues_stats
-        @oldest_run_ats = oldest_run_ats
+        @max_processing_times = max_processing_times
       end
 
       def __binding__
@@ -25,11 +25,12 @@ module Sidekiq
         end
       end
 
-      def oldest_run_ats
+      def max_processing_times
+        now = Time.now.to_i
         works_per_queue = Sidekiq::Workers.new.map { |_, _, work| work }.group_by { |work| work['queue'] }
         oldest_work_per_queue = works_per_queue.map do |queue, works|
           oldest_work = works.min_by { |work| work['run_at'] }
-          [queue, oldest_work['run_at']]
+          [queue, now - oldest_work['run_at']]
         end
         oldest_work_per_queue.to_h
       end

--- a/lib/sidekiq/prometheus/exporter/templates/metrics.erb
+++ b/lib/sidekiq/prometheus/exporter/templates/metrics.erb
@@ -34,7 +34,7 @@ sidekiq_dead_jobs <%= format('%d', @overview_stats.dead_size) %>
 # TYPE sidekiq_queue_enqueued_jobs gauge
 <% @queues_stats.each do |queue| %>sidekiq_queue_enqueued_jobs{name="<%= queue.name %>"} <%= format('%d', queue.size) %>
 <% end %>
-# HELP sidekiq_queue_oldest_run_at The run_at timestamp of the oldest running job in a queue.
-# TYPE sidekiq_queue_oldest_run_at gauge
-<% @oldest_run_ats.each do |queue, run_at| %>sidekiq_queue_oldest_run_at{name="<%= queue %>"} <%= format('%i', run_at) %>
+# HELP sidekiq_queue_max_processing_time_seconds The amount of seconds between oldest job of the queue being executed and current time.
+# TYPE sidekiq_queue_max_processing_time_seconds gauge
+<% @max_processing_times.each do |queue, max_processing_time| %>sidekiq_queue_max_processing_time_seconds{name="<%= queue %>"} <%= format('%i', max_processing_time) %>
 <% end %>

--- a/lib/sidekiq/prometheus/exporter/templates/metrics.erb
+++ b/lib/sidekiq/prometheus/exporter/templates/metrics.erb
@@ -34,3 +34,7 @@ sidekiq_dead_jobs <%= format('%d', @overview_stats.dead_size) %>
 # TYPE sidekiq_queue_enqueued_jobs gauge
 <% @queues_stats.each do |queue| %>sidekiq_queue_enqueued_jobs{name="<%= queue.name %>"} <%= format('%d', queue.size) %>
 <% end %>
+# HELP sidekiq_queue_oldest_run_at The run_at timestamp of the oldest running job in a queue.
+# TYPE sidekiq_queue_oldest_run_at gauge
+<% @oldest_run_ats.each do |queue, run_at| %>sidekiq_queue_oldest_run_at{name="<%= queue %>"} <%= format('%i', run_at) %>
+<% end %>

--- a/sidekiq-prometheus-exporter.gemspec
+++ b/sidekiq-prometheus-exporter.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',                     '~> 3.0'
   spec.add_development_dependency 'rubocop',                   '~> 0.58'
   spec.add_development_dependency 'rubocop-rspec',             '~> 1.28.0'
+  spec.add_development_dependency 'timecop',                   '~> 0.9'
 end

--- a/spec/sidekiq/prometheus/exporter_spec.rb
+++ b/spec/sidekiq/prometheus/exporter_spec.rb
@@ -45,6 +45,11 @@ sidekiq_queue_latency_seconds{name="additional"} 1.002
 # TYPE sidekiq_queue_enqueued_jobs gauge
 sidekiq_queue_enqueued_jobs{name="default"} 1
 sidekiq_queue_enqueued_jobs{name="additional"} 0
+
+# HELP sidekiq_queue_oldest_run_at The run_at timestamp of the oldest running job in a queue.
+# TYPE sidekiq_queue_oldest_run_at gauge
+sidekiq_queue_oldest_run_at{name="default"} 1527582108
+sidekiq_queue_oldest_run_at{name="additional"} 1527588610
       TEXT
       # rubocop:enable Layout/IndentHeredoc
     end
@@ -60,10 +65,19 @@ sidekiq_queue_enqueued_jobs{name="additional"} 0
         instance_double(Sidekiq::Queue, name: 'additional', size: 0, latency: 1.00200001)
       ]
     end
+    let(:workers) do
+      [
+        ['worker1:1:0493e4117adb', '2oe', {'queue' => 'default', 'run_at' => 1_527_582_108, 'payload' => {}}],
+        ['worker1:1:0493e4117adb', '2si', {'queue' => 'default', 'run_at' => 1_527_583_108, 'payload' => {}}],
+        ['worker2:1:dbf573ecf819', '2hi', {'queue' => 'additional', 'run_at' => 1_527_589_610, 'payload' => {}}],
+        ['worker2:1:dbf573ecf819', '2s8', {'queue' => 'additional', 'run_at' => 1_527_588_610, 'payload' => {}}]
+      ]
+    end
 
     before do
       allow(Sidekiq::Stats).to receive(:new).and_return(stats)
       allow(Sidekiq::Queue).to receive(:all).and_return(queues)
+      allow(Sidekiq::Workers).to receive(:new).and_return(workers)
 
       get '/metrics'
     end

--- a/spec/sidekiq/prometheus/exporter_spec.rb
+++ b/spec/sidekiq/prometheus/exporter_spec.rb
@@ -76,16 +76,12 @@ sidekiq_queue_max_processing_time_seconds{name="additional"} 40
     end
 
     before do
+      Timecop.freeze(now)
       allow(Sidekiq::Stats).to receive(:new).and_return(stats)
       allow(Sidekiq::Queue).to receive(:all).and_return(queues)
       allow(Sidekiq::Workers).to receive(:new).and_return(workers)
 
-      Timecop.freeze(now)
       get '/metrics'
-    end
-
-    after do
-      Timecop.return
     end
 
     it { expect(response).to be_ok }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'rack/test'
 require 'simplecov'
 require 'sidekiq/web'
+require 'timecop'
 
 SimpleCov.start
 


### PR DESCRIPTION
The idea is to be able to monitor for long running jobs per queue. Based on the new metric, you could add queue specific alerting rules in Prometheus, e.g. if the longest running job has been running for more than an hour.