### PR TITLE
Enclosed Metrics in Sidekiq::Prometheus module to ensure no naming conflicts arise

### DIFF
--- a/lib/sidekiq/prometheus/exporter/metrics.rb
+++ b/lib/sidekiq/prometheus/exporter/metrics.rb
@@ -1,24 +1,27 @@
 # frozen_string_literal: true
 
 require 'sidekiq/api'
+module Sidekiq
+  module Prometheus
+    class Metrics
+      QueueStats = Struct.new(:name, :size, :latency)
 
-class Metrics
-  QueueStats = Struct.new(:name, :size, :latency)
+      def initialize
+        @overview_stats = Sidekiq::Stats.new
+        @queues_stats = queues_stats
+      end
 
-  def initialize
-    @overview_stats = Sidekiq::Stats.new
-    @queues_stats = queues_stats
-  end
+      def __binding__
+        binding
+      end
 
-  def __binding__
-    binding
-  end
+      private
 
-  private
-
-  def queues_stats
-    Sidekiq::Queue.all.map do |queue|
-      QueueStats.new(queue.name, queue.size, queue.latency)
+      def queues_stats
+        Sidekiq::Queue.all.map do |queue|
+          QueueStats.new(queue.name, queue.size, queue.latency)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We are using this gem in a couple of applications and we were seeing naming conflicts, regarding the Metrics class.

Enclosed Metrics inside module Sidekiq::Prometheus to solve the naming conflict.