### PR TITLE
Proposal to add Sidekiq::Cron stats

### DIFF
--- a/lib/sidekiq/prometheus/exporter/metrics.rb
+++ b/lib/sidekiq/prometheus/exporter/metrics.rb
@@ -9,6 +9,7 @@ module Sidekiq
 
       def initialize
         @overview_stats = Sidekiq::Stats.new
+        @cron_stats = cron_stats
         @queues_stats = queues_stats
         @max_processing_times = max_processing_times
       end
@@ -18,6 +19,14 @@ module Sidekiq
       end
 
       private
+
+      def cron_stats
+        return {enabled: false} unless defined?(::Sidekiq::Cron::Job)
+        {
+          enabled: true,
+          count: ::Sidekiq::Cron::Job.all.count
+        }
+      end
 
       def queues_stats
         Sidekiq::Queue.all.map do |queue|

--- a/lib/sidekiq/prometheus/exporter/templates/metrics.erb
+++ b/lib/sidekiq/prometheus/exporter/templates/metrics.erb
@@ -38,3 +38,8 @@ sidekiq_dead_jobs <%= format('%d', @overview_stats.dead_size) %>
 # TYPE sidekiq_queue_max_processing_time_seconds gauge
 <% @max_processing_times.each do |queue, max_processing_time| %>sidekiq_queue_max_processing_time_seconds{name="<%= queue %>"} <%= format('%i', max_processing_time) %>
 <% end %>
+<% if @cron_stats[:enabled] %>
+# HELP sidekiq_cron_jobs The total number of cron jobs.
+# TYPE sidekiq_cron_jobs gauge
+sidekiq_cron_jobs_total <%= format('%d', @cron_stats[:count]) %>
+<% end %>

--- a/spec/sidekiq/prometheus/exporter_spec.rb
+++ b/spec/sidekiq/prometheus/exporter_spec.rb
@@ -50,6 +50,7 @@ sidekiq_queue_enqueued_jobs{name="additional"} 0
 # TYPE sidekiq_queue_max_processing_time_seconds gauge
 sidekiq_queue_max_processing_time_seconds{name="default"} 20
 sidekiq_queue_max_processing_time_seconds{name="additional"} 40
+
       TEXT
       # rubocop:enable Layout/IndentHeredoc
     end


### PR DESCRIPTION
We use [Sidekiq::Cron](https://github.com/ondrejbartas/sidekiq-cron) to schedule jobs with sidekiq. We would like to include some metrics (like total number of cronjobs defined), would it be possible to include this in the `sidekiq-prometheus-exporter`?

(Note: this is a work-in-progress, I at least want to add some testing)