### PR TITLE
Dockerized app with parameterised redis host & port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!config.ru

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.7-alpine
+
+WORKDIR /usr/app
+
+RUN gem install sidekiq-prometheus-exporter -v '~> 0.1'
+
+COPY config.ru .
+
+EXPOSE 9292
+
+ENTRYPOINT ["sh", "-c", "rackup -p9292 -o0.0.0.0"]

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,8 @@
+require 'sidekiq'
+require 'sidekiq/prometheus/exporter'
+
+Sidekiq.configure_client do |config|
+  config.redis = {url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}"}
+end
+
+run Sidekiq::Prometheus::Exporter.to_app


### PR DESCRIPTION
> While running sidekiq workers in containerised environments, it would be helpful to have the exporter run within a container native to the rest of the application ecosystem.

*copy-paste from the issue*

Closes #23 