### PR TITLE
Helm chart for kubernetes deployment

### DIFF
--- a/helm-charts/sidekiq-prometheus-exporter/.helmignore
+++ b/helm-charts/sidekiq-prometheus-exporter/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/sidekiq-prometheus-exporter/Chart.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.1"
+appVersion: "0.1.13"
 description: A Helm chart to deploy sidekiq-prometheus-exporter in Kubernetes
 name: sidekiq-prometheus-exporter
 version: 0.1.0

--- a/helm-charts/sidekiq-prometheus-exporter/Chart.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.1"
+description: A Helm chart to deploy sidekiq-prometheus-exporter in Kubernetes
+name: sidekiq-prometheus-exporter
+version: 0.1.0

--- a/helm-charts/sidekiq-prometheus-exporter/README.md
+++ b/helm-charts/sidekiq-prometheus-exporter/README.md
@@ -23,9 +23,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Parameter                       | Description                                                                                 | Default                             |
 |---------------------------------|---------------------------------------------------------------------------------------------|-------------------------------------|
-| `replicaCount`                  | Number of nodes                                                                             | `1`                                 |
 | `image.repository`              | Image repository                                                                            | `strech/sidekiq-prometheus-exporter`|
-| `image.tag`                     | Image tag                                                                                   | `latest`                            |
+| `image.tag`                     | Image tag                                                                                   | `0.1.13`                            |
 | `image.pullPolicy`              | Image pull policy                                                                           | `IfNotPresent`                      |
 | `imagePullSecrets`              | Image pull secrets                                                                          | `[]`                                |
 | `nameOverride`                  | Override the resource name prefix                                                           | `""`                                |
@@ -39,15 +38,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                      | Affinity settings for pod assignment                                                        | `{}`                                |
 | `externalEnvVars.type`          | Type of resource Secret/ConfigMap to source environment variables from.                     | `ConfigMap`                         |
 | `externalEnvVars.name`          | Name of Secret/ConfigMap to source environment variables from. Blank to not source either.  | `""`                                |
-| `servicemonitor.enabled`        | Whether servicemonitor resource should be deployed                                          | `true`                              |
-| `servicemonitor.path`           | The endpoint of the service to be scraped                                                   | `/metrics`                          |
-| `servicemonitor.interval`       | Duration between 2 consecutive scrapes                                                      | `10s`                               |
-| `servicemonitor.labels`         | Labels to add to the service monitor object                                                 | `{}`                                |
-| `servicemonitor.scrapeTimeout`  | Timeout for each scrape request                                                             | `5s`                                |
-| `rbac.create`                   | If true, create & use RBAC resources                                                        | `false`                             |
+| `serviceMonitor.enabled`        | Whether serviceMonitor resource should be deployed                                          | `true`                              |
+| `serviceMonitor.path`           | The endpoint of the service to be scraped                                                   | `/metrics`                          |
+| `serviceMonitor.interval`       | Duration between 2 consecutive scrapes                                                      | `1m`                                |
+| `serviceMonitor.labels`         | Labels to add to the service monitor object                                                 | `{}`                                |
+| `serviceMonitor.scrapeTimeout`  | Timeout for each scrape request                                                             | `10s`                               |
+| `rbac.create`                   | If true, create & use RBAC resources                                                        | `true`                              |
 | `serviceAccount.create`         | Specifies whether a service account should be created.                                      | `true`                              |
 | `serviceAccount.name`           | Name of the service account.                                                                | `""`                                |
-| `serviceAccount.annotations`    | Custom annotations for service  account.                                                    | `{}`                                |
-| `securityContext`               | Security Context for the pod                                                                | `{runAsUser: 65534}`                |
+| `securityContext`               | Security Context for the pod                                                                | `{}`                                |
 | `livenessProbe`                 | LivenessProbe settings for tcpSocket mapping to containerPort                               | (See `values.yaml`)                 |
 | `readinessProbe`                | ReadinessProbe settings for tcpSocket mapping to containerPort                              | (See `values.yaml`)                 |

--- a/helm-charts/sidekiq-prometheus-exporter/README.md
+++ b/helm-charts/sidekiq-prometheus-exporter/README.md
@@ -1,0 +1,46 @@
+# sidekiq-prometheus-exporter helm chart
+
+## Installing the Chart
+
+To install the chart with the release name `sidekiq-prometheus-exporter`:
+
+```console
+$ git clone git@github.com:Strech/sidekiq-prometheus-exporter.git
+helm install --name sidekiq-prometheus-exporter ./helm-charts/sidekiq-prometheus-exporter
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `sidekiq-prometheus-exporter` deployment:
+
+```console
+$ helm delete --purge sidekiq-prometheus-exporter
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+| Parameter                       | Description                                                                                 | Default                             |
+|---------------------------------|---------------------------------------------------------------------------------------------|-------------------------------------|
+| `replicaCount`                  | Number of nodes                                                                             | `1`                                 |
+| `image.repository`              | Image repository                                                                            | `strech/sidekiq-prometheus-exporter`|
+| `image.tag`                     | Image tag                                                                                   | `latest`                            |
+| `image.pullPolicy`              | Image pull policy                                                                           | `IfNotPresent`                      |
+| `imagePullSecrets`              | Image pull secrets                                                                          | `[]`                                |
+| `nameOverride`                  | Override the resource name prefix                                                           | `""`                                |
+| `fullnameOverride`              | Override the full resource names                                                            | `""`                                |
+| `service.type`                  | Kubernetes service type                                                                     | `ClusterIP`                         |
+| `service.port`                  | Kubernetes port where service is exposed                                                    | `80`                                |
+| `containerPort`                 | Port for the exporter to bind on                                                            | `9292`                              |
+| `resources`                     | CPU/Memory resource requests/limits                                                         | `{}`                                |
+| `nodeSelector`                  | Node labels for pod assignment                                                              | `{}`                                |
+| `tolerations`                   | Toleration labels for pod assignment                                                        | `[]`                                |
+| `affinity`                      | Affinity settings for pod assignment                                                        | `{}`                                |
+| `externalEnvVars.type`          | Type of resource Secret/ConfigMap to source environment variables from.                     | `ConfigMap`                         |
+| `externalEnvVars.name`          | Name of Secret/ConfigMap to source environment variables from. Blank to not source either.  | `""`                                |
+| `servicemonitor.enabled`        | Whether servicemonitor resource should be deployed                                          | `true`                              |
+| `servicemonitor.path`           | The endpoint of the service to be scraped                                                   | `/metrics`                          |
+| `servicemonitor.interval`       | Duration between 2 consecutive scrapes                                                      | `10s`                               |
+| `servicemonitor.labels`         | Labels to add to the service monitor object                                                 | `{}`                                |
+| `servicemonitor.scrapeTimeout`  | Timeout for each scrape request                                                             | `5s`                                |

--- a/helm-charts/sidekiq-prometheus-exporter/README.md
+++ b/helm-charts/sidekiq-prometheus-exporter/README.md
@@ -49,3 +49,5 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.name`           | Name of the service account.                                                                | `""`                                |
 | `serviceAccount.annotations`    | Custom annotations for service  account.                                                    | `{}`                                |
 | `securityContext`               | Security Context for the pod                                                                | `{runAsUser: 65534}`                |
+| `livenessProbe`                 | LivenessProbe settings for tcpSocket mapping to containerPort                               | (See `values.yaml`)                 |
+| `readinessProbe`                | ReadinessProbe settings for tcpSocket mapping to containerPort                              | (See `values.yaml`)                 |

--- a/helm-charts/sidekiq-prometheus-exporter/README.md
+++ b/helm-charts/sidekiq-prometheus-exporter/README.md
@@ -44,3 +44,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `servicemonitor.interval`       | Duration between 2 consecutive scrapes                                                      | `10s`                               |
 | `servicemonitor.labels`         | Labels to add to the service monitor object                                                 | `{}`                                |
 | `servicemonitor.scrapeTimeout`  | Timeout for each scrape request                                                             | `5s`                                |
+| `rbac.create`                   | If true, create & use RBAC resources                                                        | `false`                             |
+| `serviceAccount.create`         | Specifies whether a service account should be created.                                      | `true`                              |
+| `serviceAccount.name`           | Name of the service account.                                                                | `""`                                |
+| `serviceAccount.annotations`    | Custom annotations for service  account.                                                    | `{}`                                |
+| `securityContext`               | Security Context for the pod                                                                | `{runAsUser: 65534}`                |

--- a/helm-charts/sidekiq-prometheus-exporter/templates/NOTES.txt
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Get the application URL by running these commands:
+Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sidekiq-prometheus-exporter.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -10,6 +10,6 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "sidekiq-prometheus-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:9292 to use your application"
+  kubectl port-forward $POD_NAME 9292:{{ .Values.containerPort  }}
 {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/NOTES.txt
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sidekiq-prometheus-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "sidekiq-prometheus-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sidekiq-prometheus-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "sidekiq-prometheus-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/_helpers.tpl
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sidekiq-prometheus-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sidekiq-prometheus-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sidekiq-prometheus-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "sidekiq-prometheus-exporter.labels" -}}
+app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
+helm.sh/chart: {{ include "sidekiq-prometheus-exporter.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/_helpers.tpl
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sidekiq-prometheus-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sidekiq-prometheus-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/clusterrole.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+    {{- if eq .Values.externalEnvVars.type "Secret" }}
+    - "secrets"
+    {{- else }}
+    - "configmap"
+    {{- end }}
+    resourceNames: ["{{ .Values.externalEnvVars.name }}"]
+    verbs: ["get"]
+{{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/clusterrole.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources:

--- a/helm-charts/sidekiq-prometheus-exporter/templates/clusterrolebinding.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/clusterrolebinding.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/clusterrolebinding.yaml
@@ -4,10 +4,10 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+    name: {{ include "sidekiq-prometheus-exporter.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -58,3 +58,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+      serviceAccountName: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+    {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -40,6 +40,14 @@ spec:
                 name: {{ .Values.externalEnvVars.name }}
             {{- end }}
           {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.containerPort }}
+{{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.containerPort }}
+{{- toYaml .Values.readinessProbe | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sidekiq-prometheus-exporter.fullname" . }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if eq .Values.externalEnvVars.name "" }}
+          env:
+          {{- range $key, $value := .Values.envVars }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- else }}
+          envFrom:
+            {{- if eq .Values.externalEnvVars.type "Secret" }}
+            - secretRef:
+                name: {{ .Values.externalEnvVars.name }}
+            {{- else }}
+            - configMapRef:
+                name: {{ .Values.externalEnvVars.name }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   name: {{ include "sidekiq-prometheus-exporter.fullname" . }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
@@ -15,6 +15,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -43,13 +47,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ .Values.containerPort }}
-{{- toYaml .Values.livenessProbe | nindent 12 }}
+              {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.containerPort }}
-{{- toYaml .Values.readinessProbe | nindent 12 }}
+              {{- toYaml .Values.readinessProbe | nindent 12 }}
           ports:
-            - name: http
+            - name: metrics
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           resources:
@@ -68,9 +72,8 @@ spec:
     {{- end }}
     {{- with .Values.securityContext }}
       securityContext:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.serviceAccount.create }}
-      serviceAccount: {{ template "sidekiq-prometheus-exporter.fullname" . }}
-      serviceAccountName: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+      serviceAccountName: {{ include "sidekiq-prometheus-exporter.serviceAccountName" . }}
     {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/service.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/service.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: {{ include "sidekiq-prometheus-exporter.fullname" . }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: metrics
       protocol: TCP
       name: metrics
   selector:

--- a/helm-charts/sidekiq-prometheus-exporter/templates/service.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sidekiq-prometheus-exporter.fullname" . }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/serviceaccount.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+  annotations:
+  {{- if .Values.serviceAccount.annotations }}
+    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/serviceaccount.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/serviceaccount.yaml
@@ -4,9 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
-  annotations:
-  {{- if .Values.serviceAccount.annotations }}
-    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-  {{- end }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
 {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/servicemonitor.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/servicemonitor.yaml
@@ -1,25 +1,25 @@
-{{- if .Values.servicemonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
-{{- with .Values.servicemonitor.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- include "sidekiq-prometheus-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ template "sidekiq-prometheus-exporter.fullname" . }}
   selector:
     matchLabels:
-{{ include "sidekiq-prometheus-exporter.labels" . | indent 6 }}
+      {{- include "sidekiq-prometheus-exporter.labels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
   endpoints:
   - port: metrics
-    path: {{ .Values.servicemonitor.path }}
-    interval: {{ .Values.servicemonitor.interval }}
-    scrapeTimeout: {{ .Values.servicemonitor.scrapeTimeout }}
+    path: {{ .Values.serviceMonitor.path }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/templates/servicemonitor.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 4 }}
+{{- with .Values.servicemonitor.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  jobLabel: {{ template "sidekiq-prometheus-exporter.fullname" . }}
+  selector:
+    matchLabels:
+{{ include "sidekiq-prometheus-exporter.labels" . | indent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: metrics
+    path: {{ .Values.servicemonitor.path }}
+    interval: {{ .Values.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/helm-charts/sidekiq-prometheus-exporter/values.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/values.yaml
@@ -2,11 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: strech/sidekiq-prometheus-exporter
-  tag: latest
+  tag: 0.1.13
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -46,17 +44,19 @@ envVars: {}
   # REDIS_PORT: 6379
   # REDIS_URL: ""
   # REDIS_PASSWORD: ""
-  # REDIS_DB_NUMBER: ""
+  # REDIS_DB_NUMBER: "0"
   # REDIS_NAMESPACE: ""
   # REDIS_SENTINELS: ""
-  # REDIS_SENTINEL_ROLE: ""
+  # REDIS_SENTINEL_ROLE: "master"
 
-servicemonitor:
-  enabled: true
+podAnnotations: {}
+
+serviceMonitor:
+  enabled: false
   path: "/metrics"
-  interval: 10s
+  interval: 1m
   labels: {}
-  scrapeTimeout: 5s
+  scrapeTimeout: 10s
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
@@ -64,14 +64,12 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  # annotations:
-  # Will add the provided map to the annotations for the created serviceAccount
 
 rbac:
   # Specifies whether RBAC resources should be created
-  create: false
-securityContext:
-  runAsUser: 65534
+  create: true
+securityContext: {}
+  # runAsUser: 65534
 livenessProbe:
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/helm-charts/sidekiq-prometheus-exporter/values.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/values.yaml
@@ -72,3 +72,15 @@ rbac:
   create: false
 securityContext:
   runAsUser: 65534
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3

--- a/helm-charts/sidekiq-prometheus-exporter/values.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/values.yaml
@@ -1,0 +1,59 @@
+# Default values for sidekiq-prometheus-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: strech/sidekiq-prometheus-exporter
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 9292
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+externalEnvVars:
+  name: ""
+  type: "ConfigMap"
+
+envVars: {}
+  # REDIS_HOST: "localhost"
+  # REDIS_PORT: 6379
+  # REDIS_URL: ""
+  # REDIS_PASSWORD: ""
+  # REDIS_DB_NUMBER: ""
+  # REDIS_NAMESPACE: ""
+  # REDIS_SENTINELS: ""
+  # REDIS_SENTINEL_ROLE: ""
+
+servicemonitor:
+  enabled: true
+  path: "/metrics"
+  interval: 10s
+  labels: {}
+  scrapeTimeout: 5s

--- a/helm-charts/sidekiq-prometheus-exporter/values.yaml
+++ b/helm-charts/sidekiq-prometheus-exporter/values.yaml
@@ -57,3 +57,18 @@ servicemonitor:
   interval: 10s
   labels: {}
   scrapeTimeout: 5s
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # annotations:
+  # Will add the provided map to the annotations for the created serviceAccount
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: false
+securityContext:
+  runAsUser: 65534


### PR DESCRIPTION
Once merged, we can use github pages to publish the chart and update the documentation.

Closes #26 