### PR TITLE
Add option to not set client name in Sidekiq

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,7 @@ Optional
 - `REDIS_PASSWORD` - a Redis password (if you need one)
 - `REDIS_DB_NUMBER` - a Redis database number (default: `0`)
 - `REDIS_NAMESPACE` - a Redis [namespace][namespace] name (if you have separated sidekiq)
+- `REDIS_NO_CLIENT_NAME` - informs Sidekiq not to set a client name for the Redis connection (this might be required if a SaaS Redis provider is being used, which blocks the `CLIENT` command)
 - `REDIS_SENTINELS` - a list of comma separated Redis urls (like `REDIS_URL`, but for sentinels)
 - `REDIS_SENTINEL_ROLE` - a role within the [sentinel][sentinel] to connect (default: `master`)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ Optional
 - `REDIS_PASSWORD` - a Redis password (if you need one)
 - `REDIS_DB_NUMBER` - a Redis database number (default: `0`)
 - `REDIS_NAMESPACE` - a Redis [namespace][namespace] name (if you have separated sidekiq)
-- `REDIS_NO_CLIENT_NAME` - informs Sidekiq not to set a client name for the Redis connection (this might be required if a SaaS Redis provider is being used, which blocks the `CLIENT` command)
+- `REDIS_DISABLE_CLIENT_ID` - informs Sidekiq not to set a client name for the Redis connection (this might be required if a SaaS Redis provider is being used, which blocks the `CLIENT` command)
 - `REDIS_SENTINELS` - a list of comma separated Redis urls (like `REDIS_URL`, but for sentinels)
 - `REDIS_SENTINEL_ROLE` - a role within the [sentinel][sentinel] to connect (default: `master`)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ Optional
 - `REDIS_PASSWORD` - a Redis password (if you need one)
 - `REDIS_DB_NUMBER` - a Redis database number (default: `0`)
 - `REDIS_NAMESPACE` - a Redis [namespace][namespace] name (if you have separated sidekiq)
-- `REDIS_DISABLE_CLIENT_ID` - informs Sidekiq not to set a client name for the Redis connection (this might be required if a SaaS Redis provider is being used, which blocks the `CLIENT` command)
+- `REDIS_DISABLE_CLIENT_ID` - informs Sidekiq not to set a client id for the Redis connection (this might be required if a SaaS Redis provider is being used, which blocks the `CLIENT` command)
 - `REDIS_SENTINELS` - a list of comma separated Redis urls (like `REDIS_URL`, but for sentinels)
 - `REDIS_SENTINEL_ROLE` - a role within the [sentinel][sentinel] to connect (default: `master`)
 

--- a/docker/config.ru
+++ b/docker/config.ru
@@ -33,7 +33,7 @@ if ENV.key?('REDIS_SENTINELS')
   end
 end
 
-config[:id] = nil if ENV.fetch('REDIS_NO_CLIENT_NAME', false).to_s.downcase == 'true'
+config[:id] = nil if ENV.fetch('REDIS_NO_CLIENT_NAME', false).to_s.casecomp('true').zero?
 
 Sidekiq.configure_client { |client| client.redis = config }
 

--- a/docker/config.ru
+++ b/docker/config.ru
@@ -33,6 +33,8 @@ if ENV.key?('REDIS_SENTINELS')
   end
 end
 
+config[:id] = nil if ENV.fetch('REDIS_NO_CLIENT_NAME', false).to_s.downcase == 'true'
+
 Sidekiq.configure_client { |client| client.redis = config }
 
 run Sidekiq::Prometheus::Exporter.to_app

--- a/docker/config.ru
+++ b/docker/config.ru
@@ -33,7 +33,7 @@ if ENV.key?('REDIS_SENTINELS')
   end
 end
 
-config[:id] = nil if ENV.fetch('REDIS_NO_CLIENT_NAME', false).to_s.casecomp('true').zero?
+config[:id] = nil if ENV.key?('REDIS_DISABLE_CLIENT_ID')
 
 Sidekiq.configure_client { |client| client.redis = config }
 


### PR DESCRIPTION
This is necessary in case you use some SaaS Redis and the `CLIENT` command is blocked, c.f. #32.