### PR TITLE
Add worker stats per queue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL repository="strech/sidekiq-prometheus-exporter"
 ENV RACK_VERSION 2.0.9
 ENV SIDEKIQ_VERSION 6.2.1
 ENV REDIS_NAMESPACE_VERSION 1.8.1
-ENV SIDEKIQ_PROMETHEUS_EXPORTER_VERSION 0.1.15
+ENV SIDEKIQ_PROMETHEUS_EXPORTER_VERSION 0.1.16
 
 RUN    addgroup -S exporter \
     && adduser -s /bin/false -SDHg exporter exporter \

--- a/lib/sidekiq/prometheus/exporter/standard.rb
+++ b/lib/sidekiq/prometheus/exporter/standard.rb
@@ -51,8 +51,8 @@ module Sidekiq
         end
 
         def workers_stats_by_queue
-          sidekiq_processes.inject(Hash.new) do |by_queue, process|
-            process["queues"].each do |queue|
+          sidekiq_processes.each_with_object({}) do |process, by_queue|
+            process['queues'].each do |queue|
               by_queue[queue] ||= { 'workers' => 0, 'processes' => 0, 'busy_workers' => 0 }
               by_queue[queue]['workers'] += process['concurrency']
               by_queue[queue]['busy_workers'] += process['busy']

--- a/lib/sidekiq/prometheus/exporter/templates/standard.erb
+++ b/lib/sidekiq/prometheus/exporter/templates/standard.erb
@@ -46,3 +46,15 @@ sidekiq_dead_jobs <%= format('%d', @overview_stats.dead_size) %>
 # TYPE sidekiq_queue_max_processing_time_seconds gauge
 <% @max_processing_times.each do |queue, max_processing_time| %>sidekiq_queue_max_processing_time_seconds{name="<%= queue %>"} <%= format('%i', max_processing_time) %>
 <% end %>
+# HELP sidekiq_queue_workers The number of workers per queue.
+# TYPE sidekiq_queue_workers gauge
+<% @workers_stats_by_queue.each do |queue, workers_stats| %>sidekiq_queue_workers{name="<%= queue %>"} <%= format('%i', workers_stats['workers']) %>
+<% end %>
+# HELP sidekiq_queue_processes The number of processes per queue.
+# TYPE sidekiq_queue_processes gauge
+<% @workers_stats_by_queue.each do |queue, workers_stats| %>sidekiq_queue_processes{name="<%= queue %>"} <%= format('%i', workers_stats['processes']) %>
+<% end %>
+# HELP sidekiq_queue_busy_workers The number of busy_workers per queue.
+# TYPE sidekiq_queue_busy_workers gauge
+<% @workers_stats_by_queue.each do |queue, workers_stats| %>sidekiq_queue_busy_workers{name="<%= queue %>"} <%= format('%i', workers_stats['busy_workers']) %>
+<% end %>

--- a/lib/sidekiq/prometheus/exporter/version.rb
+++ b/lib/sidekiq/prometheus/exporter/version.rb
@@ -3,7 +3,7 @@
 module Sidekiq
   module Prometheus
     module Exporter
-      VERSION = '0.1.15'.freeze
+      VERSION = '0.1.16'.freeze
     end
   end
 end

--- a/spec/sidekiq/prometheus/exporter/standard_spec.rb
+++ b/spec/sidekiq/prometheus/exporter/standard_spec.rb
@@ -53,6 +53,32 @@ RSpec.describe Sidekiq::Prometheus::Exporter::Standard do
           'busy' => 6,
           'beat' => 1556226339.9993315,
           'quiet' => 'false'
+        },
+        {
+          'hostname' => '67d363edf4c3',
+          'started_at' => 1556027330.3044038,
+          'pid' => 1,
+          'tag' => 'background-3',
+          'concurrency' => 10,
+          'queues' => %w(additional),
+          'labels' => [],
+          'identity' => '67d363edf4c3:1:caadfbfe6cf8',
+          'busy' => 2,
+          'beat' => 1556226339.9993315,
+          'quiet' => 'false'
+        },
+        {
+          'hostname' => '4a35e08812e2',
+          'started_at' => 1556027330.3044038,
+          'pid' => 1,
+          'tag' => 'background-4',
+          'concurrency' => 32,
+          'queues' => %w(default additional),
+          'labels' => [],
+          'identity' => '4a35e08812e2:1:0ac802b40e1f',
+          'busy' => 8,
+          'beat' => 1556226339.9993315,
+          'quiet' => 'false'
         }
       ]
     end
@@ -68,7 +94,7 @@ RSpec.describe Sidekiq::Prometheus::Exporter::Standard do
 
         # HELP sidekiq_workers The number of workers across all the processes.
         # TYPE sidekiq_workers gauge
-        sidekiq_workers 64
+        sidekiq_workers 106
 
         # HELP sidekiq_processes The number of processes.
         # TYPE sidekiq_processes gauge
@@ -108,6 +134,21 @@ RSpec.describe Sidekiq::Prometheus::Exporter::Standard do
         # TYPE sidekiq_queue_max_processing_time_seconds gauge
         sidekiq_queue_max_processing_time_seconds{name="default"} 20
         sidekiq_queue_max_processing_time_seconds{name="additional"} 40
+
+        # HELP sidekiq_queue_workers The number of workers per queue.
+        # TYPE sidekiq_queue_workers gauge
+        sidekiq_queue_workers{name="default"} 96
+        sidekiq_queue_workers{name="additional"} 42
+
+        # HELP sidekiq_queue_processes The number of processes per queue.
+        # TYPE sidekiq_queue_processes gauge
+        sidekiq_queue_processes{name="default"} 3
+        sidekiq_queue_processes{name="additional"} 2
+
+        # HELP sidekiq_queue_busy_workers The number of busy_workers per queue.
+        # TYPE sidekiq_queue_busy_workers gauge
+        sidekiq_queue_busy_workers{name="default"} 16
+        sidekiq_queue_busy_workers{name="additional"} 10
       TEXT
     end
 


### PR DESCRIPTION
# Add support for multi queue in workers gauges

This change allows having a more fine grained information about workers in multi process installations.

It adds information about available_workers/busy_workers/processes per each queue present in the redis instance.

As an example:
```
[...]

# HELP sidekiq_queue_workers The number of workers per queue.
# TYPE sidekiq_queue_workers gauge
sidekiq_queue_workers{name="queue1"} 8
sidekiq_queue_workers{name="default"} 1

# HELP sidekiq_queue_processes The number of processes per queue.
# TYPE sidekiq_queue_processes gauge
sidekiq_queue_processes{name="queue1"} 1
sidekiq_queue_processes{name="default"} 1

# HELP sidekiq_queue_busy_workers The number of busy_workers per queue.
# TYPE sidekiq_queue_busy_workers gauge
sidekiq_queue_busy_workers{name="queue1"} 0
sidekiq_queue_busy_workers{name="default"} 0
```

And, of course, thanks a lot for you work, we've been using this gem in production for some time already and had not encountered any issue.
