### PR TITLE
[helm-chart] Add extraLabels to pod of sidekiq-prometheus-exporter

### DIFF
--- a/helm/sidekiq-prometheus-exporter/Chart.yaml
+++ b/helm/sidekiq-prometheus-exporter/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: 0.1.17
 description: A Helm chart to deploy sidekiq-prometheus-exporter in Kubernetes
 name: sidekiq-prometheus-exporter
-version: 0.1.17
+version: 0.1.18

--- a/helm/sidekiq-prometheus-exporter/README.md
+++ b/helm/sidekiq-prometheus-exporter/README.md
@@ -60,6 +60,8 @@ $ helm install sidekiq-metrics strech/sidekiq-prometheus-exporter --set serviceA
 | `tolerations`                  | Toleration labels for pod assignment                                                             | `nil`                                |
 | `affinity`                     | Affinity settings for pod assignment                                                             | `nil`                                |
 | `securityContext`              | Security Context for the pod                                                                     | `nil`                                |
+| `podLabels`                    | Pod labels additional to the default                                                             | `nil`                                |
+| `podAnnotations`               | Pod annotations                                                                                  | `nil`                                |
 | `livenessProbe`                | LivenessProbe settings for tcpSocket mapping to containerPort                                    | (See `values.yaml`)                  |
 | `readinessProbe`               | ReadinessProbe settings for tcpSocket mapping to containerPort                                   | (See `values.yaml`)                  |
 | `service.type`                 | Kubernetes service type                                                                          | `ClusterIP`                          |

--- a/helm/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.podExtraLabels }}
+        {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.podAnnotations }}

--- a/helm/sidekiq-prometheus-exporter/templates/deployment.yaml
+++ b/helm/sidekiq-prometheus-exporter/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "sidekiq-prometheus-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/sidekiq-prometheus-exporter/values.yaml
+++ b/helm/sidekiq-prometheus-exporter/values.yaml
@@ -97,6 +97,10 @@ containerPort: 9292
 # securityContext:
 #   runAsUser: 65534
 
+## Metrics exporter pod extra labels
+##
+# podExtraLabels:
+
 ## Metrics exporter pod Annotations
 ##
 # podAnnotations:

--- a/helm/sidekiq-prometheus-exporter/values.yaml
+++ b/helm/sidekiq-prometheus-exporter/values.yaml
@@ -97,9 +97,9 @@ containerPort: 9292
 # securityContext:
 #   runAsUser: 65534
 
-## Metrics exporter pod extra labels
+## Metrics exporter pod Labels
 ##
-# podExtraLabels:
+# podLabels:
 
 ## Metrics exporter pod Annotations
 ##


### PR DESCRIPTION
Hello,

Thanks for your work on this exporter and the associated chart! 

We have a use-case where we'd like to add extra labels on the `Deployment` since we use [`SecurityGroupPolicy`](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#deploy-securitygrouppolicy) to manage network permissions in our Kubernetes cluster, basically we'd like to set labels so that the pod can have access to our Redis instance.

Here is a (very) short PR to add that.

If you have feedback on how you'd like to have it done (or regarding the version bump), let me know. :)

Paul