### PR TITLE
Dockerfile:bump rack, sidekiq, redis namespace

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,9 @@ FROM ruby:2.7.5-alpine
 LABEL maintainer="Sergey Fedorov <oni.strech@gmail.com>"
 LABEL repository="strech/sidekiq-prometheus-exporter"
 
-ENV RACK_VERSION 2.0.9
-ENV SIDEKIQ_VERSION 6.2.1
-ENV REDIS_NAMESPACE_VERSION 1.8.1
+ENV RACK_VERSION 2.2.4
+ENV SIDEKIQ_VERSION 6.5.7
+ENV REDIS_NAMESPACE_VERSION 1.9
 ENV SIDEKIQ_PROMETHEUS_EXPORTER_VERSION 0.1.17
 
 RUN    addgroup -S exporter \


### PR DESCRIPTION
This change bumps rack to 2.2.4, sidekiq to 6.7.5, redis namespace to 1.9.

The upgrade to sidekiq 6.7.5 fixes an issue which spams logs with the warning
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
```
Upstream issue is here: https://github.com/mperham/sidekiq/issues/5202

Tested with Mastodon 4.0.2 / sidekiq 6.5.7.

For testing purposes I have a docker image available at https://github.com/users/t-lo/packages/container/package/sidekiq-prometheus-exporter (`ghcr.io/t-lo/sidekiq-prometheus-exporter:0.1.17.1`).