### PR TITLE
Remove the redundant Rack require from the test helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'bundler/setup'
 
-require 'rack'
 require 'rack/test'
 require 'timecop'
 require 'pry-byebug'


### PR DESCRIPTION
## Summary

- remove the redundant `require 'rack'` from the shared test helper
- rely on the exporter's existing direct Rack require and runtime dependency
- keep production loading and dependency constraints unchanged

Fixes #77.

## Testing

- Ruby 3.4.1 default Sidekiq 7.2 suite: 21 examples, 0 failures
- clean production entrypoint check confirms `Rack::Builder` is available
- Sidekiq 4.1, 7.2, and 8.0 compatibility suites passed during validation
- RuboCop and gem build passed during validation
- `git diff --check`
